### PR TITLE
Adding option to disable userdata for seasons

### DIFF
--- a/Jellyfin.Plugin.DisableUserData/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.DisableUserData/Configuration/PluginConfiguration.cs
@@ -12,6 +12,7 @@ public class PluginConfiguration : BasePluginConfiguration
         DisableOnNextUp = false;
         DisableOnContinueWatching = false;
         DisableOnRecentlyAdded = false;
+        DisableOnSeasons = false;
     }
 
     /// <summary>
@@ -44,12 +45,18 @@ public class PluginConfiguration : BasePluginConfiguration
     /// </summary>
     public bool DisableOnRecentlyAdded { get; set; }
 
+    /// <summary>
+    /// Disable User Data for /Shows/{id}/Seasons endpoint.
+    /// </summary>
+    public bool DisableOnSeasons { get; set; }
+
     public override string ToString()
     {
-        return $"{nameof(DisableOnAllItems)}: {DisableOnAllItems}, " +
-               $"{nameof(DisableOnCollections)}: {DisableOnCollections}, " +
-               $"{nameof(DisableOnContinueWatching)}: {DisableOnContinueWatching}, " +
-               $"{nameof(DisableOnNextUp)}: {DisableOnNextUp}, " +
-               $"{nameof(DisableOnRecentlyAdded)}: {DisableOnRecentlyAdded}";
+         return $"{nameof(DisableOnAllItems)}: {DisableOnAllItems}, " +
+             $"{nameof(DisableOnCollections)}: {DisableOnCollections}, " +
+             $"{nameof(DisableOnContinueWatching)}: {DisableOnContinueWatching}, " +
+             $"{nameof(DisableOnNextUp)}: {DisableOnNextUp}, " +
+             $"{nameof(DisableOnRecentlyAdded)}: {DisableOnRecentlyAdded}, " +
+             $"{nameof(DisableOnSeasons)}: {DisableOnSeasons}";
     }
 }

--- a/Jellyfin.Plugin.DisableUserData/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.DisableUserData/Configuration/PluginConfiguration.cs
@@ -13,6 +13,8 @@ public class PluginConfiguration : BasePluginConfiguration
         DisableOnContinueWatching = false;
         DisableOnRecentlyAdded = false;
         DisableOnSeasons = false;
+        EnableRoku = true;
+        DisableLogging = false;
     }
 
     /// <summary>
@@ -51,6 +53,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool DisableOnSeasons { get; set; }
 
     /// <summary>
+    /// Enable UserData for Roku clients.
+    /// </summary>
+    public bool EnableRoku { get; set; }
+
+    /// <summary>
     /// Suppress all plugin logging output.
     /// </summary>
     public bool DisableLogging { get; set; }
@@ -63,6 +70,7 @@ public class PluginConfiguration : BasePluginConfiguration
              $"{nameof(DisableOnNextUp)}: {DisableOnNextUp}, " +
              $"{nameof(DisableOnRecentlyAdded)}: {DisableOnRecentlyAdded}, " +
              $"{nameof(DisableOnSeasons)}: {DisableOnSeasons}, " +
-             $"{nameof(DisableLogging)}: {DisableLogging}";
+             $"{nameof(EnableRoku)}: {EnableRoku}" +
+             $"{nameof(DisableLogging)}: {DisableLogging}, ";
     }
 }

--- a/Jellyfin.Plugin.DisableUserData/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.DisableUserData/Configuration/PluginConfiguration.cs
@@ -50,6 +50,11 @@ public class PluginConfiguration : BasePluginConfiguration
     /// </summary>
     public bool DisableOnSeasons { get; set; }
 
+    /// <summary>
+    /// Suppress all plugin logging output.
+    /// </summary>
+    public bool DisableLogging { get; set; }
+
     public override string ToString()
     {
          return $"{nameof(DisableOnAllItems)}: {DisableOnAllItems}, " +
@@ -57,6 +62,7 @@ public class PluginConfiguration : BasePluginConfiguration
              $"{nameof(DisableOnContinueWatching)}: {DisableOnContinueWatching}, " +
              $"{nameof(DisableOnNextUp)}: {DisableOnNextUp}, " +
              $"{nameof(DisableOnRecentlyAdded)}: {DisableOnRecentlyAdded}, " +
-             $"{nameof(DisableOnSeasons)}: {DisableOnSeasons}";
+             $"{nameof(DisableOnSeasons)}: {DisableOnSeasons}, " +
+             $"{nameof(DisableLogging)}: {DisableLogging}";
     }
 }

--- a/Jellyfin.Plugin.DisableUserData/Configuration/configPage.html
+++ b/Jellyfin.Plugin.DisableUserData/Configuration/configPage.html
@@ -1,3 +1,15 @@
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label class="emby-checkbox-label">
+                        <input id="DisableOnSeasons"
+                               name="DisableOnSeasons"
+                               type="checkbox"
+                               is="emby-checkbox" />
+                        <span>Disable User Data for TV Show Seasons</span>
+                    </label>
+                    <div class="fieldDescription">
+                        When checked, UserData is disabled for queries to <code>/Shows/&lt;id&gt;/Seasons</code>.
+                    </div>
+                </div>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -126,6 +138,8 @@
                         document.querySelector('#DisableOnRecentlyAdded').checked =
                             config.DisableOnRecentlyAdded === undefined ? false : config.DisableOnRecentlyAdded;
 
+                        document.querySelector('#DisableOnSeasons').checked =
+                            config.DisableOnSeasons === undefined ? false : config.DisableOnSeasons;
                         Dashboard.hideLoadingMsg();
                     });
             });
@@ -140,6 +154,7 @@
                         config.DisableOnContinueWatching = document.querySelector('#DisableOnContinueWatching').checked;
                         config.DisableOnNextUp = document.querySelector('#DisableOnNextUp').checked;
                         config.DisableOnRecentlyAdded = document.querySelector('#DisableOnRecentlyAdded').checked;
+                        config.DisableOnSeasons = document.querySelector('#DisableOnSeasons').checked;
 
                         ApiClient.updatePluginConfiguration(DisableUserDataConfig.pluginUniqueId, config)
                             .then(function (result) {

--- a/Jellyfin.Plugin.DisableUserData/Configuration/configPage.html
+++ b/Jellyfin.Plugin.DisableUserData/Configuration/configPage.html
@@ -1,15 +1,3 @@
-                <div class="checkboxContainer checkboxContainer-withDescription">
-                    <label class="emby-checkbox-label">
-                        <input id="DisableOnSeasons"
-                               name="DisableOnSeasons"
-                               type="checkbox"
-                               is="emby-checkbox" />
-                        <span>Disable User Data for TV Show Seasons</span>
-                    </label>
-                    <div class="fieldDescription">
-                        When checked, UserData is disabled for queries to <code>/Shows/&lt;id&gt;/Seasons</code>.
-                    </div>
-                </div>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -59,6 +47,19 @@
                     <div class="fieldDescription">
                         When checked, UserData is disabled for queries that load a Collections View.
                         Applies to <code>GetItems</code> and <code>GetItemsByUserIdLegacy</code>
+                    </div>
+                </div>
+                
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label class="emby-checkbox-label">
+                        <input id="DisableOnSeasons"
+                                name="DisableOnSeasons"
+                                type="checkbox"
+                                is="emby-checkbox" />
+                        <span>Disable User Data for TV Show Seasons</span>
+                    </label>
+                    <div class="fieldDescription">
+                        When checked, UserData is disabled for queries to <code>/Shows/&lt;id&gt;/Seasons</code>.
                     </div>
                 </div>
 

--- a/Jellyfin.Plugin.DisableUserData/Configuration/configPage.html
+++ b/Jellyfin.Plugin.DisableUserData/Configuration/configPage.html
@@ -88,6 +88,10 @@
                     </label>
                     <div class="fieldDescription">
                         Applies to <code>GetNextUp</code>.
+                        <br>
+                        <span style="color: #d9534f; font-size: 0.9em;">
+                            <strong>Note:</strong> This option does <u>not</u> apply to Jellyfin for Android TV due to a known bug that causes client crashes.
+                        </span>
                     </div>
 
                     <label class="emby-checkbox-label">

--- a/Jellyfin.Plugin.DisableUserData/Configuration/configPage.html
+++ b/Jellyfin.Plugin.DisableUserData/Configuration/configPage.html
@@ -90,7 +90,7 @@
                         Applies to <code>GetNextUp</code>.
                         <br>
                         <span style="color: #d9534f; font-size: 0.9em;">
-                            <strong>Note:</strong> This option does <u>not</u> apply to Jellyfin for Android TV due to a known bug that causes client crashes.
+                            <strong>Note:</strong> This option does <u>not</u> apply to Jellyfin for Android TV or Roku due to a known bug that causes client crashes.
                         </span>
                     </div>
 

--- a/Jellyfin.Plugin.DisableUserData/Configuration/configPage.html
+++ b/Jellyfin.Plugin.DisableUserData/Configuration/configPage.html
@@ -163,6 +163,9 @@
 
                         document.querySelector('#DisableOnSeasons').checked =
                             config.DisableOnSeasons === undefined ? false : config.DisableOnSeasons;
+
+                        document.querySelector('#DisableLogging').checked =
+                            config.DisableLogging === undefined ? false : config.DisableLogging;
                         Dashboard.hideLoadingMsg();
                     });
             });
@@ -178,6 +181,7 @@
                         config.DisableOnNextUp = document.querySelector('#DisableOnNextUp').checked;
                         config.DisableOnRecentlyAdded = document.querySelector('#DisableOnRecentlyAdded').checked;
                         config.DisableOnSeasons = document.querySelector('#DisableOnSeasons').checked;
+                        config.DisableLogging = document.querySelector('#DisableLogging').checked;
 
                         ApiClient.updatePluginConfiguration(DisableUserDataConfig.pluginUniqueId, config)
                             .then(function (result) {

--- a/Jellyfin.Plugin.DisableUserData/Configuration/configPage.html
+++ b/Jellyfin.Plugin.DisableUserData/Configuration/configPage.html
@@ -90,7 +90,7 @@
                         Applies to <code>GetNextUp</code>.
                         <br>
                         <span style="color: #d9534f; font-size: 0.9em;">
-                            <strong>Note:</strong> This option does <u>not</u> apply to Jellyfin for Android TV or Roku due to a known bug that causes client crashes.
+                            <strong>Note:</strong> This option does <u>not</u> apply to Jellyfin for Android TV due to a known bug that causes client crashes.
                         </span>
                     </div>
 
@@ -108,7 +108,20 @@
 
                 <hr />
 
-                <h3>Logging</h3>
+                <h3>Global settings</h3>
+
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label class="emby-checkbox-label">
+                        <input id="EnableRoku"
+                               name="EnableRoku"
+                               type="checkbox"
+                               is="emby-checkbox" />
+                        <span>Enable Roku UserData</span>
+                    </label>
+                    <div class="fieldDescription">
+                        UserData cannot be disabled in Roku due to a known bug that causes client crashes.
+                    </div>
+                </div>
 
                 <div class="checkboxContainer checkboxContainer-withDescription">
                     <label class="emby-checkbox-label">
@@ -164,6 +177,10 @@
                         document.querySelector('#DisableOnSeasons').checked =
                             config.DisableOnSeasons === undefined ? false : config.DisableOnSeasons;
 
+                        document.querySelector('#EnableRoku').checked =
+                            config.EnableRoku === undefined ? true : config.EnableRoku;
+                        Dashboard.hideLoadingMsg();
+
                         document.querySelector('#DisableLogging').checked =
                             config.DisableLogging === undefined ? false : config.DisableLogging;
                         Dashboard.hideLoadingMsg();
@@ -182,6 +199,7 @@
                         config.DisableOnRecentlyAdded = document.querySelector('#DisableOnRecentlyAdded').checked;
                         config.DisableOnSeasons = document.querySelector('#DisableOnSeasons').checked;
                         config.DisableLogging = document.querySelector('#DisableLogging').checked;
+                        config.EnableRoku = document.querySelector('#EnableRoku').checked;
 
                         ApiClient.updatePluginConfiguration(DisableUserDataConfig.pluginUniqueId, config)
                             .then(function (result) {

--- a/Jellyfin.Plugin.DisableUserData/Configuration/configPage.html
+++ b/Jellyfin.Plugin.DisableUserData/Configuration/configPage.html
@@ -106,6 +106,24 @@
                     </div>
                 </div>
 
+                <hr />
+
+                <h3>Logging</h3>
+
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label class="emby-checkbox-label">
+                        <input id="DisableLogging"
+                               name="DisableLogging"
+                               type="checkbox"
+                               is="emby-checkbox" />
+                        <span>Disable Jellyfin Logging</span>
+                    </label>
+                    <div class="fieldDescription">
+                        For those that hate the log spam.
+                    </div>
+                </div>
+
+
                 <div>
                     <button is="emby-button"
                             type="submit"

--- a/Jellyfin.Plugin.DisableUserData/DisableUserDataActionFilter.cs
+++ b/Jellyfin.Plugin.DisableUserData/DisableUserDataActionFilter.cs
@@ -166,33 +166,30 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
         return false;
     }
 
-    private void DisableUserData(ActionExecutingContext context)
-    {
-        context.ActionArguments["enableUserData"] = false;
-    }
-
     // Disables UserData for /Shows/{id}/Seasons endpoint
-    private bool DisabledForSeasonsEndpoint(PluginConfiguration config, ActionExecutingContext context, HttpRequest request)
+    private bool DisabledForSeasonsEndpoint(
+        PluginConfiguration config,
+        ActionExecutingContext context,
+        HttpRequest request)
     {
         if (!config.DisableOnSeasons)
         {
             return false;
         }
 
-        // Match /Shows/{id}/Seasons (case-insensitive)
-        var path = request.Path.ToString();
-        if (path != null)
+        if (request.Path.ToString().EndsWith("/Seasons", StringComparison.InvariantCultureIgnoreCase))
         {
-            var segments = path.TrimEnd('/').Split('/');
-            if (segments.Length >= 3 && segments[^2].Equals("Shows", StringComparison.InvariantCultureIgnoreCase)
-                && segments[^1].Equals("Seasons", StringComparison.InvariantCultureIgnoreCase))
-            {
-                DisableUserData(context);
-                _logger.LogInformation("Disabling UserData for Seasons endpoint at path {Path}", request.Path);
-                return true;
-            }
+            DisableUserData(context);
+            _logger.LogInformation("Disabling UserData for Seasons at path {Path}", request.Path);
+            return true;
         }
+        
         return false;
+    }
+
+    private void DisableUserData(ActionExecutingContext context)
+    {
+        context.ActionArguments["enableUserData"] = false;
     }
 
 }

--- a/Jellyfin.Plugin.DisableUserData/DisableUserDataActionFilter.cs
+++ b/Jellyfin.Plugin.DisableUserData/DisableUserDataActionFilter.cs
@@ -138,9 +138,13 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
         }
 
         // Check if client is Jellyfin for Android TV or Roku
-        if (IsAndroidTvOrRokuClient(request))
+        if (IsAndroidTvClient(request))
         {
-            _logger.LogInformation("Skipping UserData disabling for Next Up due to Android/Roku TV bug at path {Path}", request.Path);
+            _logger.LogInformation("Skipping UserData disabling for Next Up due to Android TV bug at path {Path}", request.Path);
+            return false;
+        } else if (IsRokuClient(request))
+        {
+            _logger.LogInformation("Skipping UserData disabling for Next Up due to Roku bug at path {Path}", request.Path);
             return false;
         }
 
@@ -200,13 +204,13 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
         context.ActionArguments["enableUserData"] = false;
     }
 
-    private static bool IsAndroidTvOrRokuClient(HttpRequest request)
+    private static bool IsAndroidTvClient(HttpRequest request)
     {
-        // Best signal: X-Emby-Authorization header with Client="jellyfin-androidtv" or "roku"
+        // Best signal: X-Emby-Authorization header with Client="jellyfin-androidtv"
         if (request.Headers.TryGetValue("X-Emby-Authorization", out var embyAuthHeader))
         {
             var auth = embyAuthHeader.ToString().ToLowerInvariant();
-            if (auth.Contains("client=\"jellyfin-androidtv\"") || auth.Contains("client=\"roku\""))
+            if (auth.Contains("client=\"jellyfin-androidtv\""))
             {
                 return true;
             }
@@ -215,7 +219,7 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
         if (request.Query.TryGetValue("client", out var client))
         {
             var clientStr = client.ToString().ToLowerInvariant();
-            if (clientStr.Contains("jellyfin-androidtv") || clientStr.Contains("roku"))
+            if (clientStr.Contains("jellyfin-androidtv"))
             {
                 return true;
             }
@@ -224,7 +228,39 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
         if (request.Headers.TryGetValue("User-Agent", out var userAgent))
         {
             var ua = userAgent.ToString().ToLowerInvariant();
-            if (ua.Contains("androidtv") || ua.Contains("android tv") || ua.Contains("jellyfin-androidtv") || ua.Contains("roku"))
+            if (ua.Contains("androidtv") || ua.Contains("android tv") || ua.Contains("jellyfin-androidtv"))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool IsRokuClient(HttpRequest request)
+    {
+        // Best signal: X-Emby-Authorization header with Client="roku"
+        if (request.Headers.TryGetValue("X-Emby-Authorization", out var embyAuthHeader))
+        {
+            var auth = embyAuthHeader.ToString().ToLowerInvariant();
+            if (auth.Contains("client=\"roku\""))
+            {
+                return true;
+            }
+        }
+        // Fallback: query param
+        if (request.Query.TryGetValue("client", out var client))
+        {
+            var clientStr = client.ToString().ToLowerInvariant();
+            if (clientStr.Contains("roku"))
+            {
+                return true;
+            }
+        }
+        // Fallback: User-Agent
+        if (request.Headers.TryGetValue("User-Agent", out var userAgent))
+        {
+            var ua = userAgent.ToString().ToLowerInvariant();
+            if (ua.Contains("roku"))
             {
                 return true;
             }

--- a/Jellyfin.Plugin.DisableUserData/DisableUserDataActionFilter.cs
+++ b/Jellyfin.Plugin.DisableUserData/DisableUserDataActionFilter.cs
@@ -14,11 +14,11 @@ namespace Jellyfin.Plugin.DisableUserData;
 public sealed class DisableUserDataActionFilter : IAsyncActionFilter
 {
     private readonly ILibraryManager _libraryManager;
-    private readonly ILogger<DisableUserDataActionFilter> _logger;
+    private readonly SuppressibleLogger<DisableUserDataActionFilter> _logger;
 
     public DisableUserDataActionFilter(
         ILibraryManager libraryManager,
-        ILogger<DisableUserDataActionFilter> logger)
+        SuppressibleLogger<DisableUserDataActionFilter> logger)
     {
         _libraryManager = libraryManager;
         _logger = logger;
@@ -34,6 +34,9 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
             await next();
             return;
         }
+
+        // Set logger suppression from config
+        _logger.DisableLogging = config.DisableLogging;
 
         var request = context.HttpContext.Request;
         _logger.LogDebug("Intercepting path {Path} to see whether we disable UserData", request.Path);

--- a/Jellyfin.Plugin.DisableUserData/DisableUserDataActionFilter.cs
+++ b/Jellyfin.Plugin.DisableUserData/DisableUserDataActionFilter.cs
@@ -62,7 +62,18 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
         ActionExecutingContext context,
         HttpRequest request)
     {
-        if (request.Path.ToString().EndsWith("/Items", StringComparison.InvariantCultureIgnoreCase) && config.DisableOnAllItems)
+        if (!config.DisableOnAllItems)
+        {
+            return false;
+        }
+        // Check if client is Jellyfin for Roku
+        if (config.EnableRoku && IsRokuClient(request))
+        {
+            _logger.LogInformation("Skipping UserData disabling due to Roku bug at path {Path}", request.Path);
+            return false;
+        }
+
+        if (request.Path.ToString().EndsWith("/Items", StringComparison.InvariantCultureIgnoreCase))
         {
             DisableUserData(context);
             _logger.LogInformation("Disabling UserData for folder at path {Path}", request.Path);
@@ -79,6 +90,12 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
     {
         if (!config.DisableOnCollections)
         {
+            return false;
+        }
+        // Check if client is Jellyfin for Roku
+        if (config.EnableRoku && IsRokuClient(request))
+        {
+            _logger.LogInformation("Skipping UserData disabling due to Roku bug at path {Path}", request.Path);
             return false;
         }
 
@@ -118,6 +135,12 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
         {
             return false;
         }
+        // Check if client is Jellyfin for Roku
+        if (config.EnableRoku && IsRokuClient(request))
+        {
+            _logger.LogInformation("Skipping UserData disabling due to Roku bug at path {Path}", request.Path);
+            return false;
+        }
 
         if (request.Path.ToString().EndsWith("/Resume", StringComparison.InvariantCultureIgnoreCase))
         {
@@ -129,7 +152,7 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
         return false;
     }
 
-    // NOTE: Due to a known bug in Jellyfin for Android TV and Roku, disabling UserData for NextUp causes client crashes.
+    // NOTE: Due to a known bug in Jellyfin for Android TV, disabling UserData for NextUp causes client crashes.
     private bool DisabledForNextUp(
         PluginConfiguration config,
         ActionExecutingContext context,
@@ -139,15 +162,17 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
         {
             return false;
         }
+        // Check if client is Jellyfin for Roku
+        if (config.EnableRoku && IsRokuClient(request))
+        {
+            _logger.LogInformation("Skipping UserData disabling due to Roku bug at path {Path}", request.Path);
+            return false;
+        }
 
-        // Check if client is Jellyfin for Android TV or Roku
+        // Check if client is Jellyfin for Android TV
         if (IsAndroidTvClient(request))
         {
             _logger.LogInformation("Skipping UserData disabling for Next Up due to Android TV bug at path {Path}", request.Path);
-            return false;
-        } else if (IsRokuClient(request))
-        {
-            _logger.LogInformation("Skipping UserData disabling for Next Up due to Roku bug at path {Path}", request.Path);
             return false;
         }
 
@@ -189,6 +214,12 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
     {
         if (!config.DisableOnSeasons)
         {
+            return false;
+        }
+        // Check if client is Jellyfin for Roku
+        if (config.EnableRoku && IsRokuClient(request))
+        {
+            _logger.LogInformation("Skipping UserData disabling due to Roku bug at path {Path}", request.Path);
             return false;
         }
 

--- a/Jellyfin.Plugin.DisableUserData/DisableUserDataActionFilter.cs
+++ b/Jellyfin.Plugin.DisableUserData/DisableUserDataActionFilter.cs
@@ -18,10 +18,10 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
 
     public DisableUserDataActionFilter(
         ILibraryManager libraryManager,
-        SuppressibleLogger<DisableUserDataActionFilter> logger)
+        ILogger<DisableUserDataActionFilter> logger)
     {
         _libraryManager = libraryManager;
-        _logger = logger;
+        _logger = new SuppressibleLogger<DisableUserDataActionFilter>(logger);
     }
 
     public async Task OnActionExecutionAsync(

--- a/Jellyfin.Plugin.DisableUserData/DisableUserDataActionFilter.cs
+++ b/Jellyfin.Plugin.DisableUserData/DisableUserDataActionFilter.cs
@@ -126,8 +126,7 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
         return false;
     }
 
-    // NOTE: Due to a known bug in Jellyfin for Android TV, disabling UserData for NextUp causes client crashes.
-    // This method skips disabling UserData for Android TV clients.
+    // NOTE: Due to a known bug in Jellyfin for Android TV and Roku, disabling UserData for NextUp causes client crashes.
     private bool DisabledForNextUp(
         PluginConfiguration config,
         ActionExecutingContext context,
@@ -138,11 +137,10 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
             return false;
         }
 
-        // Check if client is Jellyfin for Android TV
-        if (request.Query.TryGetValue("client", out var client) &&
-            client.ToString().Equals("jellyfin-androidtv", StringComparison.OrdinalIgnoreCase))
+        // Check if client is Jellyfin for Android TV or Roku
+        if (IsAndroidTvOrRokuClient(request))
         {
-            _logger.LogInformation("Skipping UserData disabling for Next Up due to Android TV bug at path {Path}", request.Path);
+            _logger.LogInformation("Skipping UserData disabling for Next Up due to Android/Roku TV bug at path {Path}", request.Path);
             return false;
         }
 
@@ -202,4 +200,35 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
         context.ActionArguments["enableUserData"] = false;
     }
 
+    private static bool IsAndroidTvOrRokuClient(HttpRequest request)
+    {
+        // Best signal: X-Emby-Authorization header with Client="jellyfin-androidtv" or "roku"
+        if (request.Headers.TryGetValue("X-Emby-Authorization", out var embyAuthHeader))
+        {
+            var auth = embyAuthHeader.ToString().ToLowerInvariant();
+            if (auth.Contains("client=\"jellyfin-androidtv\"") || auth.Contains("client=\"roku\""))
+            {
+                return true;
+            }
+        }
+        // Fallback: query param
+        if (request.Query.TryGetValue("client", out var client))
+        {
+            var clientStr = client.ToString().ToLowerInvariant();
+            if (clientStr.Contains("jellyfin-androidtv") || clientStr.Contains("roku"))
+            {
+                return true;
+            }
+        }
+        // Fallback: User-Agent
+        if (request.Headers.TryGetValue("User-Agent", out var userAgent))
+        {
+            var ua = userAgent.ToString().ToLowerInvariant();
+            if (ua.Contains("androidtv") || ua.Contains("android tv") || ua.Contains("jellyfin-androidtv") || ua.Contains("roku"))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/Jellyfin.Plugin.DisableUserData/DisableUserDataActionFilter.cs
+++ b/Jellyfin.Plugin.DisableUserData/DisableUserDataActionFilter.cs
@@ -195,6 +195,12 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
         {
             return false;
         }
+        // Check if client is Jellyfin for Roku
+        if (config.EnableRoku && IsRokuClient(request))
+        {
+            _logger.LogInformation("Skipping UserData disabling due to Roku bug at path {Path}", request.Path);
+            return false;
+        }
 
         if (request.Path.ToString().EndsWith("/Latest", StringComparison.InvariantCultureIgnoreCase))
         {

--- a/Jellyfin.Plugin.DisableUserData/DisableUserDataActionFilter.cs
+++ b/Jellyfin.Plugin.DisableUserData/DisableUserDataActionFilter.cs
@@ -126,6 +126,8 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
         return false;
     }
 
+    // NOTE: Due to a known bug in Jellyfin for Android TV, disabling UserData for NextUp causes client crashes.
+    // This method skips disabling UserData for Android TV clients.
     private bool DisabledForNextUp(
         PluginConfiguration config,
         ActionExecutingContext context,
@@ -133,6 +135,14 @@ public sealed class DisableUserDataActionFilter : IAsyncActionFilter
     {
         if (!config.DisableOnNextUp)
         {
+            return false;
+        }
+
+        // Check if client is Jellyfin for Android TV
+        if (request.Query.TryGetValue("client", out var client) &&
+            client.ToString().Equals("jellyfin-androidtv", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogInformation("Skipping UserData disabling for Next Up due to Android TV bug at path {Path}", request.Path);
             return false;
         }
 

--- a/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
+++ b/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
@@ -8,8 +8,8 @@
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
-    <AssemblyVersion>0.2.1.1</AssemblyVersion>
-    <FileVersion>0.2.1.1</FileVersion>
+    <AssemblyVersion>0.2.1.2</AssemblyVersion>
+    <FileVersion>0.2.1.2</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
+++ b/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
@@ -8,8 +8,8 @@
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
-    <AssemblyVersion>0.2.1.2</AssemblyVersion>
-    <FileVersion>0.2.1.2</FileVersion>
+    <AssemblyVersion>0.2.1.3</AssemblyVersion>
+    <FileVersion>0.2.1.3</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
+++ b/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
@@ -8,8 +8,8 @@
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
-    <AssemblyVersion>0.2.1.3</AssemblyVersion>
-    <FileVersion>0.2.1.3</FileVersion>
+    <AssemblyVersion>0.2.1.4</AssemblyVersion>
+    <FileVersion>0.2.1.4</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
+++ b/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
@@ -8,8 +8,8 @@
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
-    <AssemblyVersion>0.2.1.11</AssemblyVersion>
-    <FileVersion>0.2.1.11</FileVersion>
+    <AssemblyVersion>0.2.1.12</AssemblyVersion>
+    <FileVersion>0.2.1.12</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
+++ b/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
@@ -8,8 +8,8 @@
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
-    <AssemblyVersion>0.2.1.8</AssemblyVersion>
-    <FileVersion>0.2.1.8</FileVersion>
+    <AssemblyVersion>0.2.1.9</AssemblyVersion>
+    <FileVersion>0.2.1.9</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
+++ b/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
@@ -8,8 +8,8 @@
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
-    <AssemblyVersion>0.2.1.6</AssemblyVersion>
-    <FileVersion>0.2.1.6</FileVersion>
+    <AssemblyVersion>0.2.1.7</AssemblyVersion>
+    <FileVersion>0.2.1.7</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
+++ b/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
@@ -8,8 +8,8 @@
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
-    <AssemblyVersion>0.2.1.4</AssemblyVersion>
-    <FileVersion>0.2.1.4</FileVersion>
+    <AssemblyVersion>0.2.1.5</AssemblyVersion>
+    <FileVersion>0.2.1.5</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
+++ b/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
@@ -8,8 +8,8 @@
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
-    <AssemblyVersion>0.2.1.9</AssemblyVersion>
-    <FileVersion>0.2.1.9</FileVersion>
+    <AssemblyVersion>0.2.1.10</AssemblyVersion>
+    <FileVersion>0.2.1.10</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
+++ b/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
@@ -8,8 +8,8 @@
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
-    <AssemblyVersion>0.2.1.10</AssemblyVersion>
-    <FileVersion>0.2.1.10</FileVersion>
+    <AssemblyVersion>0.2.1.11</AssemblyVersion>
+    <FileVersion>0.2.1.11</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
+++ b/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
@@ -8,8 +8,8 @@
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
-    <AssemblyVersion>0.2.1.5</AssemblyVersion>
-    <FileVersion>0.2.1.5</FileVersion>
+    <AssemblyVersion>0.2.1.6</AssemblyVersion>
+    <FileVersion>0.2.1.6</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
+++ b/Jellyfin.Plugin.DisableUserData/Jellyfin.Plugin.DisableUserData.csproj
@@ -8,8 +8,8 @@
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
-    <AssemblyVersion>0.2.1.7</AssemblyVersion>
-    <FileVersion>0.2.1.7</FileVersion>
+    <AssemblyVersion>0.2.1.8</AssemblyVersion>
+    <FileVersion>0.2.1.8</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.DisableUserData/Plugin.cs
+++ b/Jellyfin.Plugin.DisableUserData/Plugin.cs
@@ -42,7 +42,7 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
                 {
                     [$"{BaseName}.ItemsController"] = ImmutableList.Create("GetItemsByUserIdLegacy", "GetItems", "GetResumeItemsLegacy", "GetResumeItems"),
                     [$"{BaseName}.UserLibraryController"] = ImmutableList.Create("GetLatestMediaLegacy", "GetLatestMedia"),
-                    [$"{BaseName}.TvShowsController"] = ImmutableList.Create("GetNextUp")
+                    [$"{BaseName}.TvShowsController"] = ImmutableList.Create("GetNextUp", "GetSeasons")
                 };
                 var count = actionDescriptorProvider.AddDynamicFilter<DisableUserDataActionFilter>(
                     serviceProvider,

--- a/Jellyfin.Plugin.DisableUserData/SuppressibleLogger.cs
+++ b/Jellyfin.Plugin.DisableUserData/SuppressibleLogger.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace Jellyfin.Plugin.DisableUserData
+{
+    /// <summary>
+    /// Logger wrapper that suppresses log output when DisableLogging is true.
+    /// </summary>
+    public class SuppressibleLogger<T> : ILogger<T>
+    {
+        private readonly ILogger<T> _innerLogger;
+        /// <summary>
+        /// If true, all log output is suppressed.
+        /// </summary>
+        public bool DisableLogging { get; set; } = false;
+
+        public SuppressibleLogger(ILogger<T> innerLogger)
+        {
+            _innerLogger = innerLogger;
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return _innerLogger.BeginScope(state);
+        }
+
+        /// <summary>
+        /// Returns false if logging is suppressed, otherwise delegates to inner logger.
+        /// </summary>
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return !DisableLogging && _innerLogger.IsEnabled(logLevel);
+        }
+
+        /// <summary>
+        /// Only logs if IsEnabled returns true.
+        /// </summary>
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (IsEnabled(logLevel))
+            {
+                _innerLogger.Log(logLevel, eventId, state, exception, formatter);
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Disable UserData Plugin
 
+For this branch, you must update your plugin manifest to the one in this project:
+```
+https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/raw/refs/heads/main/manifest.json
+```
+
 ## Introduction
 For many people, versions 10.11.x (latest one being 10.11.3 as of this writing) results in a very slow loading of collections, and sometimes for home items. The issue is discussed in the upstream issues:
 
@@ -20,8 +25,8 @@ While trying to debug the issue, I noticed that a large portion of the slowdown 
     "Key": "ef8c5f5b-26c8-814b-bfae-3e4499649c2a",
     "ItemId": "ef8c5f5b26c8814bbfae3e4499649c2a"
   }
-  ```
-  Many APIs support directly passing in an `enableUserData` parameter. When this is set to `false`, slowdown caused by the above issues is significantly mitigated, at the cost of losing Unwatched badges and / or progress percentage in the UI, which in some cases may not matter.
+```
+Many APIs support directly passing in an `enableUserData` parameter. When this is set to `false`, slowdown caused by the above issues is significantly mitigated, at the cost of losing Unwatched badges and / or progress percentage in the UI, which in some cases may not matter.
 
 ## What the plugin does
 
@@ -53,7 +58,7 @@ Because it's server-wide, this is expected to work across clients. This has been
 1. Add a new repository to Jellyfin with the following URL:
 
     ```
-    https://raw.githubusercontent.com/pelluch/jellyfin-plugins/refs/heads/main/manifest.json
+    https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/raw/refs/heads/main/manifest.json
     ```
 
     And any name you like (e.g. pelluch Plugins).

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Disable User Data"
 guid: "b24c5930-c337-4e0f-977f-1d900629ad09"
-version: "0.2.1.2"
+version: "0.2.1.3"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Disables user data in certain API calls"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Disable User Data"
 guid: "b24c5930-c337-4e0f-977f-1d900629ad09"
-version: "0.2.1.3"
+version: "0.2.1.4"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Disables user data in certain API calls"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Disable User Data"
 guid: "b24c5930-c337-4e0f-977f-1d900629ad09"
-version: "0.2.1.0"
+version: "0.2.1.2"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Disables user data in certain API calls"
@@ -13,4 +13,4 @@ owner: "pelluch"
 artifacts:
 - "Jellyfin.Plugin.DisableUserData.dll"
 changelog: >
-  changelog
+  Added feature for blocking user data in seasons.

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Disable User Data"
 guid: "b24c5930-c337-4e0f-977f-1d900629ad09"
-version: "0.2.1.10"
+version: "0.2.1.11"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Disables user data in certain API calls"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Disable User Data"
 guid: "b24c5930-c337-4e0f-977f-1d900629ad09"
-version: "0.2.1.4"
+version: "0.2.1.5"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Disables user data in certain API calls"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Disable User Data"
 guid: "b24c5930-c337-4e0f-977f-1d900629ad09"
-version: "0.2.1.5"
+version: "0.2.1.6"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Disables user data in certain API calls"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Disable User Data"
 guid: "b24c5930-c337-4e0f-977f-1d900629ad09"
-version: "0.2.1.11"
+version: "0.2.1.12"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Disables user data in certain API calls"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Disable User Data"
 guid: "b24c5930-c337-4e0f-977f-1d900629ad09"
-version: "0.2.1.9"
+version: "0.2.1.10"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Disables user data in certain API calls"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Disable User Data"
 guid: "b24c5930-c337-4e0f-977f-1d900629ad09"
-version: "0.2.1.8"
+version: "0.2.1.9"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Disables user data in certain API calls"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Disable User Data"
 guid: "b24c5930-c337-4e0f-977f-1d900629ad09"
-version: "0.2.1.7"
+version: "0.2.1.8"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Disables user data in certain API calls"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Disable User Data"
 guid: "b24c5930-c337-4e0f-977f-1d900629ad09"
-version: "0.2.1.6"
+version: "0.2.1.7"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Disables user data in certain API calls"
@@ -9,7 +9,7 @@ description: >
   Disables user data in configurable API points in order
   to speed up queries
 category: "General"
-owner: "pelluch"
+owner: "kinggeorges12"
 artifacts:
 - "Jellyfin.Plugin.DisableUserData.dll"
 changelog: >

--- a/manifest.json
+++ b/manifest.json
@@ -11,9 +11,9 @@
                 "checksum": "b686c02a9a989d232f9c4fd910834c8f",
                 "changelog": "Added feature for blocking user data in seasons.",
                 "targetAbi": "10.11.0.0",
-                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.3/disable-user-data_0.2.1.3.zip",
+                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.4/disable-user-data_0.2.1.4.zip",
                 "timestamp": "2025-11-26T03:29:24Z",
-                "version": "0.2.1.3"
+                "version": "0.2.1.4"
             },
             {
                 "checksum": "bcae5ecdccb28a96bb6e213d20111be2",

--- a/manifest.json
+++ b/manifest.json
@@ -11,9 +11,9 @@
                 "checksum": "3e884f8961f12a66278a095cc857ef57",
                 "changelog": "Added feature for blocking user data in seasons.",
                 "targetAbi": "10.11.0.0",
-                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.2/disable-user-data_0.2.1.0.zip",
+                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.3/disable-user-data_0.2.1.0.zip",
                 "timestamp": "2025-11-26T03:29:24Z",
-                "version": "0.2.1.2"
+                "version": "0.2.1.3"
             },
             {
                 "checksum": "bcae5ecdccb28a96bb6e213d20111be2",

--- a/manifest.json
+++ b/manifest.json
@@ -8,10 +8,10 @@
         "overview": "Disable user data param for speed-ups",
         "versions": [
             {
-                "checksum": "3e884f8961f12a66278a095cc857ef57",
+                "checksum": "b686c02a9a989d232f9c4fd910834c8f",
                 "changelog": "Added feature for blocking user data in seasons.",
                 "targetAbi": "10.11.0.0",
-                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.3/disable-user-data_0.2.1.0.zip",
+                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.3/disable-user-data_0.2.1.3.zip",
                 "timestamp": "2025-11-26T03:29:24Z",
                 "version": "0.2.1.3"
             },

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
         "overview": "Disable user data param for speed-ups",
         "versions": [
             {
-                "checksum": "358862588bca5cf6573a4f57b3028b78",
+                "checksum": "a105a9771ad29b85542433f964da0a27",
                 "changelog": "Added feature for blocking user data in seasons.",
                 "targetAbi": "10.11.0.0",
                 "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.2/disable-user-data_0.2.1.0.zip",

--- a/manifest.json
+++ b/manifest.json
@@ -16,14 +16,6 @@
                 "version": "0.2.1.4"
             },
             {
-                "checksum": "b686c02a9a989d232f9c4fd910834c8f",
-                "changelog": "Added feature for blocking user data in seasons.",
-                "targetAbi": "10.11.0.0",
-                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.3/disable-user-data_0.2.1.3.zip",
-                "timestamp": "2026-01-21T15:21:00Z",
-                "version": "0.2.1.3"
-            },
-            {
                 "checksum": "bcae5ecdccb28a96bb6e213d20111be2",
                 "changelog": "Properly set assembly version",
                 "targetAbi": "10.11.0.0",

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,52 @@
+[
+    {
+        "category": "General",
+        "guid": "b24c5930-c337-4e0f-977f-1d900629ad09",
+        "name": "Disable User Data",
+        "description": "Omits UserData (watch status / progress) from different endpoints in order to speed up queries.",
+        "owner": "pelluch",
+        "overview": "Disable user data param for speed-ups",
+        "versions": [
+            {
+                "checksum": "bcae5ecdccb28a96bb6e213d20111be2",
+                "changelog": "Properly set assembly version",
+                "targetAbi": "10.11.0.0",
+                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.2/DisableUserData_0.2.1.2.zip",
+                "timestamp": "2025-11-26T03:29:24Z",
+                "version": "0.2.1.2"
+            },
+            {
+                "checksum": "bcae5ecdccb28a96bb6e213d20111be2",
+                "changelog": "Properly set assembly version",
+                "targetAbi": "10.11.0.0",
+                "sourceUrl": "https://github.com/pelluch/jellyfin-plugin-disable-user-data/releases/download/0.2.1.1/DisableUserData_0.2.1.1.zip",
+                "timestamp": "2025-11-26T03:29:24Z",
+                "version": "0.2.1.1"
+            },
+            {
+                "checksum": "068a039735f6560b13709c1721f4168b",
+                "changelog": "Bug fix for all items option",
+                "targetAbi": "10.11.0.0",
+                "sourceUrl": "https://github.com/pelluch/jellyfin-plugin-disable-user-data/releases/download/0.2.1.0/DisableUserData_0.2.1.0.zip",
+                "timestamp": "2025-11-26T03:17:45Z",
+                "version": "0.2.1.0"
+            },
+            {
+                "checksum": "a8ca04473d66705bb645ed2c0a6720e4",
+                "changelog": "Adds more logging and option to disable user data on more items",
+                "targetAbi": "10.11.0.0",
+                "sourceUrl": "https://github.com/pelluch/jellyfin-plugin-disable-user-data/releases/download/0.2.0.0/DisableUserData_0.2.0.0.zip",
+                "timestamp": "2025-11-26T02:56:17Z",
+                "version": "0.2.0.0"
+            },
+            {
+                "checksum": "4a1d23bb90ef2fe9dc301b270a66b251",
+                "changelog": "Initial release",
+                "targetAbi": "10.11.0.0",
+                "sourceUrl": "https://github.com/pelluch/jellyfin-plugin-disable-user-data/releases/download/0.1.0.0/DisableUserData_0.1.0.0.zip",
+                "timestamp": "2025-11-25T05:37:13Z",
+                "version": "0.1.0.0"
+            }
+        ]
+    }
+]

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
         "overview": "Disable user data param for speed-ups",
         "versions": [
             {
-                "checksum": "bcae5ecdccb28a96bb6e213d20111be2",
+                "checksum": "dc059e1dcb873d153f33da248e7e4b5a",
                 "changelog": "Properly set assembly version",
                 "targetAbi": "10.11.0.0",
                 "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.2/disable-user-data_0.2.1.0.zip",

--- a/manifest.json
+++ b/manifest.json
@@ -8,12 +8,20 @@
         "overview": "Disable user data param for speed-ups",
         "versions": [
             {
-                "checksum": "b686c02a9a989d232f9c4fd910834c8f",
+                "checksum": "25af69e724ab0f46c69a3619570d4a41",
                 "changelog": "Added feature for blocking user data in seasons.",
                 "targetAbi": "10.11.0.0",
                 "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.4/disable-user-data_0.2.1.4.zip",
-                "timestamp": "2025-11-26T03:29:24Z",
+                "timestamp": "2026-01-21T15:44:00Z",
                 "version": "0.2.1.4"
+            },
+            {
+                "checksum": "b686c02a9a989d232f9c4fd910834c8f",
+                "changelog": "Added feature for blocking user data in seasons.",
+                "targetAbi": "10.11.0.0",
+                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.3/disable-user-data_0.2.1.3.zip",
+                "timestamp": "2026-01-21T15:21:00Z",
+                "version": "0.2.1.3"
             },
             {
                 "checksum": "bcae5ecdccb28a96bb6e213d20111be2",

--- a/manifest.json
+++ b/manifest.json
@@ -8,8 +8,8 @@
         "overview": "Disable user data param for speed-ups",
         "versions": [
             {
-                "checksum": "dc059e1dcb873d153f33da248e7e4b5a",
-                "changelog": "Properly set assembly version",
+                "checksum": "358862588bca5cf6573a4f57b3028b78",
+                "changelog": "Added feature for blocking user data in seasons.",
                 "targetAbi": "10.11.0.0",
                 "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.2/disable-user-data_0.2.1.0.zip",
                 "timestamp": "2025-11-26T03:29:24Z",

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
         "overview": "Disable user data param for speed-ups",
         "versions": [
             {
-                "checksum": "a105a9771ad29b85542433f964da0a27",
+                "checksum": "3e884f8961f12a66278a095cc857ef57",
                 "changelog": "Added feature for blocking user data in seasons.",
                 "targetAbi": "10.11.0.0",
                 "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.2/disable-user-data_0.2.1.0.zip",

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
                 "checksum": "bcae5ecdccb28a96bb6e213d20111be2",
                 "changelog": "Properly set assembly version",
                 "targetAbi": "10.11.0.0",
-                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.2/DisableUserData_0.2.1.2.zip",
+                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.2/disable-user-data_0.2.1.0.zip",
                 "timestamp": "2025-11-26T03:29:24Z",
                 "version": "0.2.1.2"
             },

--- a/manifest.json
+++ b/manifest.json
@@ -11,9 +11,9 @@
                 "checksum": "7fd369894b281568dc69e7588b34e5ac",
                 "changelog": "Added option to suppress logging.",
                 "targetAbi": "10.11.0.0",
-                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.9/disable-user-data_0.2.1.9.zip",
+                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.10/disable-user-data_0.2.1.10.zip",
                 "timestamp": "2026-02-09T19:51:00Z",
-                "version": "0.2.1.9"
+                "version": "0.2.1.10"
             },
             {
                 "checksum": "50369627669f9cb35c40dec203450d23",

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
         "overview": "Disable user data param for speed-ups",
         "versions": [
             {
-                "checksum": "f9fcb70317a00159b9a1348b2f9da256",
+                "checksum": "43ab08f930c1d4eed2ce8708e433624c",
                 "changelog": "Android TV and Roku clients should no longer crash when the next up user data option is enabled.",
                 "targetAbi": "10.11.0.0",
                 "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.6/disable-user-data_0.2.1.6.zip",

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
         "overview": "Disable user data param for speed-ups",
         "versions": [
             {
-                "checksum": "25af69e724ab0f46c69a3619570d4a41",
+                "checksum": "f9fcb70317a00159b9a1348b2f9da256",
                 "changelog": "Added feature for blocking user data in seasons.",
                 "targetAbi": "10.11.0.0",
                 "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.5/disable-user-data_0.2.1.5.zip",

--- a/manifest.json
+++ b/manifest.json
@@ -11,9 +11,9 @@
                 "checksum": "43ab08f930c1d4eed2ce8708e433624c",
                 "changelog": "Android TV and Roku clients should no longer crash when the next up user data option is enabled.",
                 "targetAbi": "10.11.0.0",
-                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.6/disable-user-data_0.2.1.6.zip",
+                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.7/disable-user-data_0.2.1.7.zip",
                 "timestamp": "2026-02-09T19:51:00Z",
-                "version": "0.2.1.6"
+                "version": "0.2.1.7"
             },
             {
                 "checksum": "25af69e724ab0f46c69a3619570d4a41",

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
         "overview": "Disable user data param for speed-ups",
         "versions": [
             {
-                "checksum": "c1ce79f2f06b0b97451897aaaa9eb3ac",
+                "checksum": "e7a712ddcd9e8c24a1fee04c8e9cee7e",
                 "changelog": "Added option to enable UserData for Roku clients.",
                 "targetAbi": "10.11.0.0",
                 "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.12/disable-user-data_0.2.1.12.zip",

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
         "versions": [
             {
                 "checksum": "f9fcb70317a00159b9a1348b2f9da256",
-                "changelog": "Added feature for blocking user data in seasons.",
+                "changelog": "Android TV and Roku clients should no longer crash when the next up user data option is enabled.",
                 "targetAbi": "10.11.0.0",
                 "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.6/disable-user-data_0.2.1.6.zip",
                 "timestamp": "2026-02-09T19:51:00Z",

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
         "overview": "Disable user data param for speed-ups",
         "versions": [
             {
-                "checksum": "",
+                "checksum": "c1ce79f2f06b0b97451897aaaa9eb3ac",
                 "changelog": "Added option to enable UserData for Roku clients.",
                 "targetAbi": "10.11.0.0",
                 "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.11/disable-user-data_0.2.1.11.zip",

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
         "overview": "Disable user data param for speed-ups",
         "versions": [
             {
-                "checksum": "a2b12c9162b0d8be85c6c1d9093444b5",
+                "checksum": "7fd369894b281568dc69e7588b34e5ac",
                 "changelog": "Added option to suppress logging.",
                 "targetAbi": "10.11.0.0",
                 "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.9/disable-user-data_0.2.1.9.zip",

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,14 @@
                 "checksum": "25af69e724ab0f46c69a3619570d4a41",
                 "changelog": "Added feature for blocking user data in seasons.",
                 "targetAbi": "10.11.0.0",
+                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.5/disable-user-data_0.2.1.5.zip",
+                "timestamp": "2026-02-09T19:51:00Z",
+                "version": "0.2.1.5"
+            },
+            {
+                "checksum": "25af69e724ab0f46c69a3619570d4a41",
+                "changelog": "Added feature for blocking user data in seasons.",
+                "targetAbi": "10.11.0.0",
                 "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.4/disable-user-data_0.2.1.4.zip",
                 "timestamp": "2026-01-21T15:44:00Z",
                 "version": "0.2.1.4"

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,14 @@
         "versions": [
             {
                 "checksum": "50369627669f9cb35c40dec203450d23",
+                "changelog": "Added option to suppress logging.",
+                "targetAbi": "10.11.0.0",
+                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.8/disable-user-data_0.2.1.8.zip",
+                "timestamp": "2026-02-09T19:51:00Z",
+                "version": "0.2.1.8"
+            },
+            {
+                "checksum": "50369627669f9cb35c40dec203450d23",
                 "changelog": "Android TV and Roku clients should no longer crash when the next up user data option is enabled.",
                 "targetAbi": "10.11.0.0",
                 "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.7/disable-user-data_0.2.1.7.zip",

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
         "overview": "Disable user data param for speed-ups",
         "versions": [
             {
-                "checksum": "7fd369894b281568dc69e7588b34e5ac",
+                "checksum": "3f56c12d0fa14581715530cd9198b9f7",
                 "changelog": "Added option to suppress logging.",
                 "targetAbi": "10.11.0.0",
                 "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.10/disable-user-data_0.2.1.10.zip",

--- a/manifest.json
+++ b/manifest.json
@@ -11,9 +11,9 @@
                 "checksum": "a2b12c9162b0d8be85c6c1d9093444b5",
                 "changelog": "Added option to suppress logging.",
                 "targetAbi": "10.11.0.0",
-                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.8/disable-user-data_0.2.1.8.zip",
+                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.9/disable-user-data_0.2.1.9.zip",
                 "timestamp": "2026-02-09T19:51:00Z",
-                "version": "0.2.1.8"
+                "version": "0.2.1.9"
             },
             {
                 "checksum": "50369627669f9cb35c40dec203450d23",

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
         "overview": "Disable user data param for speed-ups",
         "versions": [
             {
-                "checksum": "50369627669f9cb35c40dec203450d23",
+                "checksum": "a2b12c9162b0d8be85c6c1d9093444b5",
                 "changelog": "Added option to suppress logging.",
                 "targetAbi": "10.11.0.0",
                 "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.8/disable-user-data_0.2.1.8.zip",

--- a/manifest.json
+++ b/manifest.json
@@ -4,16 +4,16 @@
         "guid": "b24c5930-c337-4e0f-977f-1d900629ad09",
         "name": "Disable User Data",
         "description": "Omits UserData (watch status / progress) from different endpoints in order to speed up queries.",
-        "owner": "pelluch",
+        "owner": "kinggeorges12",
         "overview": "Disable user data param for speed-ups",
         "versions": [
             {
                 "checksum": "c1ce79f2f06b0b97451897aaaa9eb3ac",
                 "changelog": "Added option to enable UserData for Roku clients.",
                 "targetAbi": "10.11.0.0",
-                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.11/disable-user-data_0.2.1.11.zip",
-                "timestamp": "2026-02-10T20:41:00Z",
-                "version": "0.2.1.11"
+                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.12/disable-user-data_0.2.1.12.zip",
+                "timestamp": "2026-02-11T00:56:00Z",
+                "version": "0.2.1.12"
             },
             {
                 "checksum": "3f56c12d0fa14581715530cd9198b9f7",

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
         "overview": "Disable user data param for speed-ups",
         "versions": [
             {
-                "checksum": "43ab08f930c1d4eed2ce8708e433624c",
+                "checksum": "50369627669f9cb35c40dec203450d23",
                 "changelog": "Android TV and Roku clients should no longer crash when the next up user data option is enabled.",
                 "targetAbi": "10.11.0.0",
                 "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.7/disable-user-data_0.2.1.7.zip",

--- a/manifest.json
+++ b/manifest.json
@@ -8,11 +8,19 @@
         "overview": "Disable user data param for speed-ups",
         "versions": [
             {
+                "checksum": "",
+                "changelog": "Added option to enable UserData for Roku clients.",
+                "targetAbi": "10.11.0.0",
+                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.11/disable-user-data_0.2.1.11.zip",
+                "timestamp": "2026-02-10T20:41:00Z",
+                "version": "0.2.1.11"
+            },
+            {
                 "checksum": "3f56c12d0fa14581715530cd9198b9f7",
                 "changelog": "Added option to suppress logging.",
                 "targetAbi": "10.11.0.0",
                 "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.10/disable-user-data_0.2.1.10.zip",
-                "timestamp": "2026-02-09T19:51:00Z",
+                "timestamp": "2026-02-09T22:06:00Z",
                 "version": "0.2.1.10"
             },
             {

--- a/manifest.json
+++ b/manifest.json
@@ -11,9 +11,9 @@
                 "checksum": "f9fcb70317a00159b9a1348b2f9da256",
                 "changelog": "Added feature for blocking user data in seasons.",
                 "targetAbi": "10.11.0.0",
-                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.5/disable-user-data_0.2.1.5.zip",
+                "sourceUrl": "https://github.com/kinggeorges12/jellyfin-plugin-disable-user-data/releases/download/0.2.1.6/disable-user-data_0.2.1.6.zip",
                 "timestamp": "2026-02-09T19:51:00Z",
-                "version": "0.2.1.5"
+                "version": "0.2.1.6"
             },
             {
                 "checksum": "25af69e724ab0f46c69a3619570d4a41",


### PR DESCRIPTION
Some TV shows with many seasons (e.g., Simpsons) actually timeout because the queries are so slow. This adds an option to disable that query for /Seasons endpoints.

Tested with Jellyfin v10.11.6 and season load times are instant.

Some of the code was generated with code bot but I had to rewrite it by hand. This caused some of the spacing to mess up.